### PR TITLE
use srcObject if createObjectURL fails

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -19,10 +19,18 @@ if (navigator.getUserMedia) {
 
       // Success callback
       function(stream) {
-      
-        var videoURL = window.URL.createObjectURL(stream);
+
         var video = document.createElement('video');
-        video.src = videoURL;
+        var videoURL;
+        try {
+          window.URL.createObjectURL(stream);
+          video.src = videoURL;
+        } catch(e) {
+          if (videoURL) {
+            window.URL.revokeObjectURL(videoURL)
+          }
+          video.srcObject = stream;
+        }
         video.onloadedmetadata = function() {
          video.play(); 
          threeRender(video);


### PR DESCRIPTION
More modern browsers use [video.srcObject](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/srcObject) instead of creating an object URL.

This uses srcObject when the object URL method fails. I tested this in Chrome 88 and it resolves this error:

> Uncaught TypeError: Failed to execute 'createObjectURL' on 'URL': Overload resolution failed.
>    at main.js:23

I also know it was an issue in Safari as early as Feb 2018.